### PR TITLE
Add RSS autodiscovery for blog and disable RSS for other page types

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -2,4 +2,5 @@
 title = 'Blog'
 date = 2023-01-01T08:30:00-07:00
 draft = false
+outputs = ['html', 'rss']
 +++

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,3 +2,5 @@ baseURL = 'https://inochi2d.com/'
 languageCode = 'en-us'
 title = 'Inochi2D'
 theme = 'inochi2d'
+
+disableKinds = ['rss']

--- a/themes/inochi2d/layouts/partials/head.html
+++ b/themes/inochi2d/layouts/partials/head.html
@@ -4,4 +4,7 @@
 <link rel="preconnect" href="https://rsms.me/">
 <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 <link rel="icon" type="image/png" href="/img/favicon.png">
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}
 {{ partialCached "head/css.html" . }}


### PR DESCRIPTION
I'm not familiar with Hugo (I followed [this page](https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head) in their docs), so I'm not sure whether I should have modified `/themes/inochi2d/hugo.toml` instead of `/hugo.toml`, though it seemed to only work on the root-level `hugo.toml`.